### PR TITLE
Fix constant refetch of audio file

### DIFF
--- a/src/components/ScrambleText.jsx
+++ b/src/components/ScrambleText.jsx
@@ -1,36 +1,31 @@
-import { useRef, useEffect } from 'react';
-import { shuffle }from 'txt-shuffle';
+import { useRef, useEffect, useState } from "react";
+import { shuffle } from "txt-shuffle";
 import audioSrc from "../assets/morse-1.wav";
 
 const ScrambleText = ({ enter, hasPermission }) => {
-   const charRef = useRef(null);
-   const targetString = "learning";
-   const originalString = ".-.. . .- .-. -. .. -. --";
-   let isPlaying = false;
+  const [chars, setChars] = useState("");
+  const audioRef = useRef(null);
+  const [canPlayThrough, setCanPlayThrough] = useState(false);
+  const targetString = "learning";
+  const originalString = ".-.. . .- .-. -. .. -. --";
 
-   
-   useEffect(() => {
-      if (enter || hasPermission) {
-            const audio = new Audio(audioSrc)
-            shuffle({ 
-               text: targetString, 
-               fps: 24, 
-               direction: 'random',
-               glyphs: originalString,
-              //  duration: audio.duration, 
-               onUpdate: (output) => {
-                  if (isPlaying) {
-                     charRef.current.innerText = output
-                  } else {
-                    audio.play();
-                     isPlaying = true
-                  }
-               },
-              //  onComplete: () => {
-              //    audio.pause();
-              //  }
-            })
-         
+  useEffect(() => {
+    if ((enter || hasPermission) && canPlayThrough) {
+      audioRef.current.play();
+      shuffle({
+        text: targetString,
+        fps: 24,
+        direction: "random",
+        glyphs: originalString,
+        duration: audioRef.current.duration,
+        onUpdate: output => {
+          setChars(output);
+        }
+        //  onComplete: () => {
+        //    audio.pause();
+        //  }
+      });
+
       //  let tl = gsap.timeline({ delay: 1, duration: audioRef.current.duration})
 
       //  tl.to(charRef.current, {
@@ -39,15 +34,20 @@ const ScrambleText = ({ enter, hasPermission }) => {
       //    //  shuffle({ text: targetString, fps: 25, onUpdate: (output) => {
       //    //    charRef.current.innerText = output
       //    //  } });
-      //  }, 
-      //  onComplete: () => { 
-      //     audioRef.current.pause(); 
+      //  },
+      //  onComplete: () => {
+      //     audioRef.current.pause();
       //    //  charRef.current.innerText = targetString
       //  }})
-       }
-     },[enter, hasPermission])
+    }
+  }, [enter, hasPermission, canPlayThrough]);
 
-  return <p ref={charRef}></p>;
+  return (
+    <>
+      <audio ref={audioRef} src={audioSrc} autoplay preload onCanPlayThrough={() => setCanPlayThrough(true)} />
+      <p>{chars}</p>
+    </>
+  );
 };
 
 export default ScrambleText;

--- a/src/components/ScrambleText.jsx
+++ b/src/components/ScrambleText.jsx
@@ -1,34 +1,36 @@
-import { useRef, useEffect } from "react";
-import { shuffle } from "txt-shuffle";
+import { useRef, useEffect } from 'react';
+import { shuffle }from 'txt-shuffle';
 import audioSrc from "../assets/morse-1.wav";
 
 const ScrambleText = ({ enter, hasPermission }) => {
-  const charRef = useRef(null);
-  const targetString = "learning";
-  const originalString = ".-.. . .- .-. -. .. -. --";
-  let isPlaying = false;
+   const charRef = useRef(null);
+   const targetString = "learning";
+   const originalString = ".-.. . .- .-. -. .. -. --";
+   let isPlaying = false;
 
-  useEffect(() => {
-    if (enter || hasPermission) {
-      const audio = new Audio(audioSrc);
-      shuffle({
-        text: targetString,
-        fps: 24,
-        direction: "random",
-        glyphs: originalString,
-        onUpdate: output => {
-          if (isPlaying) {
-            charRef.current.innerText = output;
-          } else {
-            audio.play();
-            isPlaying = true;
-          }
-        }
-        // onComplete: () => {
-        //   audio.pause();
-        // }
-      });
-
+   
+   useEffect(() => {
+      if (enter || hasPermission) {
+            const audio = new Audio(audioSrc)
+            shuffle({ 
+               text: targetString, 
+               fps: 24, 
+               direction: 'random',
+               glyphs: originalString,
+              //  duration: audio.duration, 
+               onUpdate: (output) => {
+                  if (isPlaying) {
+                     charRef.current.innerText = output
+                  } else {
+                    audio.play();
+                     isPlaying = true
+                  }
+               },
+              //  onComplete: () => {
+              //    audio.pause();
+              //  }
+            })
+         
       //  let tl = gsap.timeline({ delay: 1, duration: audioRef.current.duration})
 
       //  tl.to(charRef.current, {
@@ -37,13 +39,13 @@ const ScrambleText = ({ enter, hasPermission }) => {
       //    //  shuffle({ text: targetString, fps: 25, onUpdate: (output) => {
       //    //    charRef.current.innerText = output
       //    //  } });
-      //  },
-      //  onComplete: () => {
-      //     audioRef.current.pause();
+      //  }, 
+      //  onComplete: () => { 
+      //     audioRef.current.pause(); 
       //    //  charRef.current.innerText = targetString
       //  }})
-    }
-  }, [enter, hasPermission]);
+       }
+     },[enter, hasPermission])
 
   return <p ref={charRef}></p>;
 };

--- a/src/components/ScrambleText.jsx
+++ b/src/components/ScrambleText.jsx
@@ -7,7 +7,7 @@ const ScrambleText = ({ enter, hasPermission }) => {
   const audioRef = useRef(null);
   const [canPlayThrough, setCanPlayThrough] = useState(false);
   const targetString = "learning";
-  const originalString = ".-.. . .- .-. -. .. -. --";
+  const originalString = ".-.. . .- .-. -. .. -. --.";
 
   useEffect(() => {
     if ((enter || hasPermission) && canPlayThrough) {

--- a/src/components/ScrambleText.jsx
+++ b/src/components/ScrambleText.jsx
@@ -1,38 +1,34 @@
-import { useRef, useEffect, useState } from 'react';
-import { shuffle }from 'txt-shuffle';
+import { useRef, useEffect } from "react";
+import { shuffle } from "txt-shuffle";
 import audioSrc from "../assets/morse-1.wav";
 
 const ScrambleText = ({ enter, hasPermission }) => {
-   const charRef = useRef(null);
-   const audioRef = useRef(new Audio(audioSrc));
-   const { duration } = audioRef.current;
-   const targetString = "learning";
-   const originalString = ".-.. . .- .-. -. .. -. --";
-   let isPlaying = false;
+  const charRef = useRef(null);
+  const targetString = "learning";
+  const originalString = ".-.. . .- .-. -. .. -. --";
+  let isPlaying = false;
 
-   
-   useEffect(() => {
-      if (enter || hasPermission) {
-    
-            shuffle({ 
-               text: targetString, 
-               fps: 24, 
-               direction: 'random',
-               glyphs: originalString,
-               duration: duration, 
-               onUpdate: (output) => {
-                  if (isPlaying) {
-                     charRef.current.innerText = output
-                  } else {
-                     audioRef.current.play();
-                     isPlaying = true
-                  }
-               },
-               onComplete: () => {
-                  audioRef.current.pause();
-               }
-            })
-         
+  useEffect(() => {
+    if (enter || hasPermission) {
+      const audio = new Audio(audioSrc);
+      shuffle({
+        text: targetString,
+        fps: 24,
+        direction: "random",
+        glyphs: originalString,
+        onUpdate: output => {
+          if (isPlaying) {
+            charRef.current.innerText = output;
+          } else {
+            audio.play();
+            isPlaying = true;
+          }
+        }
+        // onComplete: () => {
+        //   audio.pause();
+        // }
+      });
+
       //  let tl = gsap.timeline({ delay: 1, duration: audioRef.current.duration})
 
       //  tl.to(charRef.current, {
@@ -41,13 +37,13 @@ const ScrambleText = ({ enter, hasPermission }) => {
       //    //  shuffle({ text: targetString, fps: 25, onUpdate: (output) => {
       //    //    charRef.current.innerText = output
       //    //  } });
-      //  }, 
-      //  onComplete: () => { 
-      //     audioRef.current.pause(); 
+      //  },
+      //  onComplete: () => {
+      //     audioRef.current.pause();
       //    //  charRef.current.innerText = targetString
       //  }})
-       }
-     },[enter, hasPermission])
+    }
+  }, [enter, hasPermission]);
 
   return <p ref={charRef}></p>;
 };


### PR DESCRIPTION
Currently, the mousePosition state re-renders the entire app since it is declared in the App component:
![image](https://github.com/user-attachments/assets/c521307f-383d-48ef-96f8-2326ab3b488b)

The problem is that this is also re-renders the ScrambleText component which loads the audio file, resulting in the audio file being fetched every time your mouse position is updated leading to hundreds of requests a second, slowing the website down considerably:
![chrome_wAnBbsDr0b](https://github.com/user-attachments/assets/239a3de8-848d-4194-ae2e-fa95ab61ff26)

This change:
- uses an actual audio element which will persist, unlike a state.
- waits for onCanPlayThrough becase until then audio.duration is NaN
- replace the charsRef with a state since the element is not being accessed
- fixes the originalString morse code which currently translates to LEARNINM because it is missing a period
